### PR TITLE
Fix case of navigation item for manual_issue page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,5 +12,5 @@ nav:
     - '4. 行政': 'manifest/administration.md'
     - '5. 民主主義': 'manifest/democracy.md'
   - '貢献したいあなたへ': 'contribution.md'
-  - 'issueマニュアル': 'manual_issue.md'
+  - 'Issueマニュアル': 'manual_issue.md'
   - 'Pull Requestマニュアル': 'manual_pull_request.md'


### PR DESCRIPTION
ナビゲーションメニューで小文字始まりなのがどうしても気になってしまったので提案してます。