### PR TITLE
Upgrade actions versions actions/checkout@v2->@v4, actions/setup-python@v2->@v5

### DIFF
--- a/.github/workflows/comment-review.yml
+++ b/.github/workflows/comment-review.yml
@@ -10,7 +10,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/comment-review.yml
+++ b/.github/workflows/comment-review.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
CIで利用しているactions/checkout, actions/setup-pythonで古いバージョンが利用されています。
特に理由がなければ最新のバージョンを利用すると良いと思います。

利用するバージョンを以下のように変更します。

- actions/checkout@v2->@v4
- actions/setup-python@v2->@v5

FYI: https://github.com/actions/setup-python?tab=readme-ov-file#basic-usage

この変更でactions/** のバージョンは全て最新になります。

```sh
git grep actions/checkout@                    
.github/workflows/comment-review.yml:      uses: actions/checkout@v4
.github/workflows/issue-review.yml:      uses: actions/checkout@v4
.github/workflows/main.yml:      - uses: actions/checkout@v4
```

```sh
git grep actions/checkout    
.github/workflows/comment-review.yml:      uses: actions/checkout@v4
.github/workflows/issue-review.yml:      uses: actions/checkout@v4
.github/workflows/main.yml:      - uses: actions/checkout@v4
```


