### PR TITLE
ラベル付与workflowのpermission修正

### DIFF
--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -5,6 +5,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   add_label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Permissionが足りずジョブが失敗していたので修正