### PR TITLE
issue templateの改善

### DIFF
--- a/.github/ISSUE_TEMPLATE/mamifest_issue_template.yaml
+++ b/.github/ISSUE_TEMPLATE/mamifest_issue_template.yaml
@@ -5,13 +5,14 @@ body:
     attributes:
       label: 政策ビジョン
       description: 該当する政策カテゴリを一つ選んでください
-      multiple: false
+      multiple: true
       options:
         - 経済
         - 医療・防災
         - 教育・子育て
         - 行政
         - 民主主義
+        - その他
     validations:
       required: true
   - type: textarea
@@ -39,7 +40,7 @@ body:
     attributes:
       label: 調べたこと（裏付けとなる事実・ファクト）
     validations:
-      required: true
+      required: false
   - type: textarea
     attributes:
       label: 自由記述欄


### PR DESCRIPTION
- 複数の政策領域にまたがる問題提起もみられるので、複数の政策領域を選べるようにしました。
- 5つの柱のどれにも該当しない場合に選択できるよう、「その他」の項目を追加しました
- できるだけハードルが下がるよう、「調べたこと」の記載欄を任意にしました