### PR TITLE
複数の政策領域のラベル付与に対応

### DIFF
--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -34,14 +34,17 @@ jobs:
             { regex: /^教育・子育て$/, label: '教育・子育て' },
             { regex: /^行政$/, label: '行政' },
             { regex: /^民主主義$/, label: '民主主義' },
+            { regex: /^その他$/, label: 'その他' },
           ];
 
           policyVisionSection.split('\n').forEach(line => {
-            categories.forEach(category => {
-              if (category.regex.test(line)) {
-                console.log(`Match: ${category.label}`);
-                labelsToAdd.push(category.label);
-              }
+            line.split(', ').forEach(item => {
+              categories.forEach(category => {
+                if (category.regex.test(item)) {
+                  console.log(`Match: ${category.label}`);
+                  labelsToAdd.push(category.label);
+                }
+              });
             });
           });
 


### PR DESCRIPTION
- 政策領域を複数選択できるようにするテンプレート変更に対応 (https://github.com/takahiroanno2024/election2024/pull/166)
    - カンマ区切りになるので`', '`でsplit
- その他ラベルを追加