### PR TITLE
CIでpipインストールのキャッシュ有効化

### DIFF
--- a/.github/workflows/issue-review.yml
+++ b/.github/workflows/issue-review.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+        cache: pip
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
+          cache: pip
       - run: pip install mkdocs-material 
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
# 概要
CIでキャッシュが使われてないが、setup-pythonにpipキャッシュ機能があるのでそれを使う
https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies

# 現状
- 現状キャッシュが使われていない
![image](https://github.com/takahiroanno2024/election2024/assets/239667/3aecaef4-29b4-4b0b-8217-4ab7b05fb91c)

- main.ymlではキャッシュを使う設定があるが、有効なパスではないエラーで動いてない
![image](https://github.com/takahiroanno2024/election2024/assets/239667/f0495074-02d7-422e-b677-9020ed2be813)
