### PR TITLE
Fix mkdocs.yml syntax

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
     - '3. 教育・子育て': 'manifest/education.md'
     - '4. 行政': 'manifest/administration.md'
     - '5. 民主主義': 'manifest/democracy.md'
-    - '6. その他': 'manifest/others.md''
+    - '6. その他': 'manifest/others.md'
   - '貢献したいあなたへ': 'contribution.md'
   - 'Issueマニュアル': 'manual_issue.md'
   - 'Pull Requestマニュアル': 'manual_pull_request.md'


### PR DESCRIPTION
- 閉じsingle quotationが2つ連続してしまっていて、GitHub Actionsが走らなくなっていたので修正